### PR TITLE
Fixed two bugs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
   <groupId>com.weblogism</groupId>
   <artifactId>vertx-lang-clojure-parent</artifactId>
 
-  <version>4.1.0-SNAPSHOT</version>
+  <version>4.1.0</version>
   <packaging>pom</packaging>
 
   <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
     <clojure.version>1.10.3</clojure.version>
     <clojure.plugin.version>1.8.4</clojure.plugin.version>
     <junit.version>4.13</junit.version>
-    <stack.version>4.1.0</stack.version>
+    <stack.version>4.5.7</stack.version>
   </properties>
 
   <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
   <groupId>com.weblogism</groupId>
   <artifactId>vertx-lang-clojure-parent</artifactId>
 
-  <version>4.1.0</version>
+  <version>4.1.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -42,9 +42,9 @@
 
   <developers>
     <developer>
-      <id>tychobrailleur</id>
-      <organization>Weblogism</organization>
-      <email>sebastien@weblogism.com</email>
+      <id>minosniu</id>
+      <organization>Sparcing</organization>
+      <email>niuchuanxin@sparcing.com</email>
     </developer>
   </developers>
 

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <clojure.version>1.10.3</clojure.version>
+    <clojure.version>1.11.2</clojure.version>
     <clojure.plugin.version>1.8.4</clojure.plugin.version>
     <junit.version>4.13</junit.version>
     <stack.version>4.5.7</stack.version>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
   </modules>
 
   <description>Vert.x Clojure Implementation</description>
-  <url>https://github.com/tychobrailleur/vertx-lang-clojure</url>
+  <url>https://github.com/minosniu/vertx-lang-clojure</url>
 
   <licenses>
     <license>
@@ -35,9 +35,9 @@
   </licenses>
 
   <scm>
-    <connection>scm:git:git@github.com:tychobrailleur/vertx-lang-clojure.git</connection>
-    <developerConnection>scm:git:git@github.com:tychobrailleur/vertx-lang-clojure.git</developerConnection>
-    <url>git@github.com:tychobrailleur/vertx-lang-clojure.git</url>
+    <connection>scm:git:git@github.com:minosniu/vertx-lang-clojure.git</connection>
+    <developerConnection>scm:git:git@github.com:minosniu/vertx-lang-clojure.git</developerConnection>
+    <url>git@github.com:minosniu/vertx-lang-clojure.git</url>
   </scm>
 
   <developers>
@@ -108,7 +108,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>1.6</version>
+            <version>3.1.0</version>
             <executions>
               <execution>
                 <id>sign-artifacts</id>
@@ -116,6 +116,10 @@
                 <goals>
                   <goal>sign</goal>
                 </goals>
+                <configuration>
+                  <keyname>E5C2C60875CAA5F35C338E60058CDC8093DC6BFA</keyname>
+                  <passphraseServerId>E5C2C60875CAA5F35C338E60058CDC8093DC6BFA</passphraseServerId>
+                </configuration>
               </execution>
             </executions>
           </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -5,13 +5,12 @@
   <parent>
     <groupId>io.vertx</groupId>
     <artifactId>vertx-parent</artifactId>
-    <version>15</version>
+    <version>19</version>
   </parent>
 
-  <groupId>com.weblogism</groupId>
+  <groupId>com.sparcing</groupId>
   <artifactId>vertx-lang-clojure-parent</artifactId>
-
-  <version>4.1.0-SNAPSHOT</version>
+  <version>4.5.7</version>
   <packaging>pom</packaging>
 
   <modules>

--- a/vertx-lang-clojure-gen/pom.xml
+++ b/vertx-lang-clojure-gen/pom.xml
@@ -4,9 +4,9 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>com.weblogism</groupId>
+    <groupId>com.sparcing</groupId>
     <artifactId>vertx-lang-clojure-parent</artifactId>
-    <version>4.1.0-SNAPSHOT</version>
+    <version>4.5.7</version>
   </parent>
 
   <artifactId>vertx-lang-clojure-gen</artifactId>

--- a/vertx-lang-clojure-gen/pom.xml
+++ b/vertx-lang-clojure-gen/pom.xml
@@ -10,7 +10,7 @@
   </parent>
 
   <artifactId>vertx-lang-clojure-gen</artifactId>
-  <version>4.1.0-SNAPSHOT</version>
+  <version>4.5.7</version>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/vertx-lang-clojure-gen/pom.xml
+++ b/vertx-lang-clojure-gen/pom.xml
@@ -6,11 +6,11 @@
   <parent>
     <groupId>com.weblogism</groupId>
     <artifactId>vertx-lang-clojure-parent</artifactId>
-    <version>4.1.0</version>
+    <version>4.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>vertx-lang-clojure-gen</artifactId>
-  <version>4.1.0</version>
+  <version>4.1.0-SNAPSHOT</version>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/vertx-lang-clojure-gen/pom.xml
+++ b/vertx-lang-clojure-gen/pom.xml
@@ -6,11 +6,11 @@
   <parent>
     <groupId>com.weblogism</groupId>
     <artifactId>vertx-lang-clojure-parent</artifactId>
-    <version>4.0.0-SNAPSHOT</version>
+    <version>4.1.0</version>
   </parent>
 
   <artifactId>vertx-lang-clojure-gen</artifactId>
-  <version>4.0.0-SNAPSHOT</version>
+  <version>4.1.0</version>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/vertx-lang-clojure-gen/src/main/java/io/vertx/lang/clojure/ClojureClassGenerator.java
+++ b/vertx-lang-clojure-gen/src/main/java/io/vertx/lang/clojure/ClojureClassGenerator.java
@@ -102,7 +102,7 @@ public class ClojureClassGenerator extends AbstractClojureCodeGenerator<ClassMod
         value.forEach((key, value1) -> {
             writer.println();
             List<String> methodArgs = new ArrayList<>();
-            methodArgs.add(kebabCaseObjName);
+            methodArgs.add(kebabCaseObjName+"-obj");
             methodArgs.addAll(value1);
             String args = methodArgs.stream().map(ClojureUtils::clojurifyName).collect(Collectors.joining(" "));
             writer.println("  ([" + args + "]");

--- a/vertx-lang-clojure/pom.xml
+++ b/vertx-lang-clojure/pom.xml
@@ -4,9 +4,9 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <parent>
-    <groupId>com.weblogism</groupId>
+    <groupId>com.sparcing</groupId>
     <artifactId>vertx-lang-clojure-parent</artifactId>
-    <version>4.1.0-SNAPSHOT</version>
+    <version>4.5.7</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/vertx-lang-clojure/pom.xml
+++ b/vertx-lang-clojure/pom.xml
@@ -6,13 +6,13 @@
   <parent>
     <groupId>com.weblogism</groupId>
     <artifactId>vertx-lang-clojure-parent</artifactId>
-    <version>4.1.0</version>
+    <version>4.1.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>vertx-lang-clojure</artifactId>
-  <version>4.1.0</version>
+  <version>4.1.0-SNAPSHOT</version>
 
   <properties>
     <log4j.version>1.2.17</log4j.version>
@@ -198,7 +198,7 @@
     <dependency>
       <groupId>com.weblogism</groupId>
       <artifactId>vertx-lang-clojure-gen</artifactId>
-      <version>4.0.0-SNAPSHOT</version>
+      <version>4.1.0-SNAPSHOT</version>
       <optional>true</optional>
     </dependency>
   </dependencies>

--- a/vertx-lang-clojure/pom.xml
+++ b/vertx-lang-clojure/pom.xml
@@ -6,13 +6,13 @@
   <parent>
     <groupId>com.weblogism</groupId>
     <artifactId>vertx-lang-clojure-parent</artifactId>
-    <version>4.1.0-SNAPSHOT</version>
+    <version>4.1.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>vertx-lang-clojure</artifactId>
-  <version>4.1.0-SNAPSHOT</version>
+  <version>4.1.0</version>
 
   <properties>
     <log4j.version>1.2.17</log4j.version>

--- a/vertx-lang-clojure/pom.xml
+++ b/vertx-lang-clojure/pom.xml
@@ -29,7 +29,7 @@
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-codegen</artifactId>
-      <version>4.1.0</version>
+      <version>4.5.7</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -246,7 +246,7 @@
               </includeArtifactIds>
               <classifier>sources</classifier>
               <!-- Prevent AuthOptions (interface) to be generated with ctor -->
-              <excludes>**/impl/**/*.java,io/vertx/groovy/**,io/vertx/reactivex/**,io/vertx/rxjava/**,examples/override/**,io/vertx/codegen/testmodel/**,io/vertx/ext/auth/AuthOptions.java</excludes>
+              <excludes>**/impl/**/*.java,io/vertx/ext/web/handler/OtpAuthHandler.java,examples/**,io/vertx/groovy/**,io/vertx/reactivex/**,io/vertx/rxjava/**,examples/override/**,io/vertx/codegen/testmodel/**,io/vertx/ext/auth/AuthOptions.java</excludes>
               <outputDirectory>${project.build.directory}/sources/vertx-core</outputDirectory>
             </configuration>
           </execution>

--- a/vertx-lang-clojure/pom.xml
+++ b/vertx-lang-clojure/pom.xml
@@ -12,7 +12,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>vertx-lang-clojure</artifactId>
-  <version>4.1.0-SNAPSHOT</version>
+  <version>4.5.7</version>
 
   <properties>
     <log4j.version>1.2.17</log4j.version>

--- a/vertx-lang-clojure/pom.xml
+++ b/vertx-lang-clojure/pom.xml
@@ -3,6 +3,9 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
+  <description>Vert.x Clojure support.</description>
+  <url>https://github.com/minosniu/vertx-lang-clojure</url>
+
   <parent>
     <groupId>com.sparcing</groupId>
     <artifactId>vertx-lang-clojure-parent</artifactId>
@@ -14,27 +17,79 @@
   <artifactId>vertx-lang-clojure</artifactId>
   <version>4.5.7</version>
 
+  <licenses>
+    <license>
+      <name>The Apache Software License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+    </license>
+    <license>
+      <name>Eclipse Public License - v1.0</name>
+      <url>http://www.eclipse.org/legal/epl-v10.html</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+
+  <scm>
+    <connection>scm:git:git@github.com:minosniu/vertx-lang-clojure.git</connection>
+    <developerConnection>scm:git:git@github.com:minosniu/vertx-lang-clojure.git</developerConnection>
+    <url>git@github.com:minosniu/vertx-lang-clojure.git</url>
+  </scm>
+
+  <developers>
+    <developer>
+      <id>minosniu</id>
+      <organization>Sparcing</organization>
+      <email>niuchuanxin@sparcing.com</email>
+    </developer>
+  </developers>
+
+  <distributionManagement>
+    <repository>
+      <id>central</id>
+      <name>central-releases</name>
+<!--      <url>https://central.sonatype.com</url>-->
+      <url>s01.oss.sonatype.org/</url>
+    </repository>
+  </distributionManagement>
+
   <properties>
     <log4j.version>1.2.17</log4j.version>
     <slf4j.version>1.7.21</slf4j.version>
     <log4j2.version>2.8.2</log4j2.version>
+    <clojure.version>1.11.2</clojure.version>
+    <vertx.version>4.5.7</vertx.version>
   </properties>
+
+<!--  <dependencyManagement>-->
+<!--    <dependencies>-->
+<!--      <dependency>-->
+<!--        <groupId>io.vertx</groupId>-->
+<!--        <artifactId>vertx-dependencies</artifactId>-->
+<!--        <version>${stack.version}</version>-->
+<!--        <type>pom</type>-->
+<!--        <scope>import</scope>-->
+<!--      </dependency>-->
+<!--    </dependencies>-->
+<!--  </dependencyManagement>-->
 
   <dependencies>
     <dependency>
       <groupId>org.clojure</groupId>
       <artifactId>clojure</artifactId>
+      <version>${clojure.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-codegen</artifactId>
-      <version>4.5.7</version>
+      <version>${vertx.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-docgen</artifactId>
+      <version>3.5.1</version>
       <optional>true</optional>
     </dependency>
     <!-- <dependency> -->
@@ -45,75 +100,90 @@
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-core</artifactId>
+      <version>${vertx.version}</version>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-web-common</artifactId>
+      <version>${vertx.version}</version>
       <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-web-client</artifactId>
+      <version>${vertx.version}</version>
       <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-web</artifactId>
+      <version>${vertx.version}</version>
       <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-auth-common</artifactId>
+      <version>${vertx.version}</version>
       <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-auth-jdbc</artifactId>
+      <version>${vertx.version}</version>
       <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-auth-htdigest</artifactId>
+      <version>${vertx.version}</version>
       <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-auth-htpasswd</artifactId>
+      <version>${vertx.version}</version>
       <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-auth-jwt</artifactId>
+      <version>${vertx.version}</version>
       <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-auth-mongo</artifactId>
+      <version>${vertx.version}</version>
       <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-auth-oauth2</artifactId>
+      <version>${vertx.version}</version>
       <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-auth-shiro</artifactId>
+      <version>${vertx.version}</version>
       <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-auth-webauthn</artifactId>
+      <version>${vertx.version}</version>
       <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-config</artifactId>
+      <version>${vertx.version}</version>
       <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-jdbc-client</artifactId>
+      <version>${vertx.version}</version>
       <optional>true</optional>
     </dependency>
 
@@ -157,18 +227,21 @@
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-codegen</artifactId>
+      <version>${vertx.version}</version>
       <classifier>tck</classifier>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-codegen</artifactId>
+      <version>${vertx.version}</version>
       <classifier>tck-sources</classifier>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-codegen</artifactId>
+      <version>${vertx.version}</version>
       <classifier>sources</classifier>
       <scope>test</scope>
     </dependency>
@@ -181,6 +254,7 @@
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-core</artifactId>
+      <version>${vertx.version}</version>
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
@@ -188,17 +262,19 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-transport-native-epoll</artifactId>
+      <version>4.1.108.Final</version>
       <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-transport-native-kqueue</artifactId>
+      <version>4.1.108.Final</version>
       <optional>true</optional>
     </dependency>
     <dependency>
-      <groupId>com.weblogism</groupId>
+      <groupId>com.sparcing</groupId>
       <artifactId>vertx-lang-clojure-gen</artifactId>
-      <version>4.1.0-SNAPSHOT</version>
+      <version>4.5.7</version>
       <optional>true</optional>
     </dependency>
   </dependencies>
@@ -207,6 +283,79 @@
 
   <build>
     <plugins>
+      <plugin>
+        <groupId>org.sonatype.central</groupId>
+        <artifactId>central-publishing-maven-plugin</artifactId>
+        <version>0.4.0</version>
+        <extensions>true</extensions>
+        <configuration>
+          <publishingServerId>central</publishingServerId>
+          <tokenAuth>true</tokenAuth>
+        </configuration>
+      </plugin>
+
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <version>3.3.0</version>
+        <executions>
+          <execution>
+            <id>attach-sources</id>
+            <goals>
+              <goal>jar-no-fork</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <version>3.6.3</version>
+        <executions>
+          <execution>
+            <id>attach-javadocs</id>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+            <configuration>
+              <doclint>none</doclint>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-gpg-plugin</artifactId>
+        <version>3.1.0</version>
+        <executions>
+          <execution>
+            <id>sign-artifacts</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>sign</goal>
+            </goals>
+            <configuration>
+              <keyname>E5C2C60875CAA5F35C338E60058CDC8093DC6BFA</keyname>
+              <passphraseServerId>E5C2C60875CAA5F35C338E60058CDC8093DC6BFA</passphraseServerId>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.sonatype.central</groupId>
+        <artifactId>central-publishing-maven-plugin</artifactId>
+        <version>0.4.0</version>
+        <extensions>true</extensions>
+        <configuration>
+          <publishingServerId>central</publishingServerId>
+          <tokenAuth>true</tokenAuth>
+          <autoPublish>true</autoPublish>
+        </configuration>
+      </plugin>
+
+
+
       <plugin>
         <artifactId>maven-dependency-plugin</artifactId>
         <configuration>

--- a/vertx-lang-clojure/src/main/java/io/vertx/lang/clojure/ClojureDocGenerator.java
+++ b/vertx-lang-clojure/src/main/java/io/vertx/lang/clojure/ClojureDocGenerator.java
@@ -1,6 +1,6 @@
 package io.vertx.lang.clojure;
 
-import io.vertx.docgen.Coordinate;
+//import io.vertx.docgen.Coordinate;
 import io.vertx.docgen.DocGenerator;
 import io.vertx.docgen.JavaDocGenerator;
 
@@ -41,18 +41,18 @@ public class ClojureDocGenerator implements DocGenerator {
     }
 
     @Override
-    public String resolveTypeLink(TypeElement elt, Coordinate coordinate) {
-        return javaGen.resolveTypeLink(elt, coordinate);
+    public String resolveTypeLink(TypeElement elt) {
+        return javaGen.resolveTypeLink(elt);
     }
 
     @Override
-    public String resolveConstructorLink(ExecutableElement elt, Coordinate coordinate) {
-        return javaGen.resolveConstructorLink(elt, coordinate);
+    public String resolveConstructorLink(ExecutableElement elt) {
+        return javaGen.resolveConstructorLink(elt);
     }
 
     @Override
-    public String resolveMethodLink(ExecutableElement elt, Coordinate coordinate) {
-        return javaGen.resolveMethodLink(elt, coordinate);
+    public String resolveMethodLink(ExecutableElement elt) {
+        return javaGen.resolveMethodLink(elt);
     }
 
     @Override
@@ -61,7 +61,7 @@ public class ClojureDocGenerator implements DocGenerator {
     }
 
     @Override
-    public String resolveFieldLink(VariableElement elt, Coordinate coordinate) {
-        return javaGen.resolveFieldLink(elt, coordinate);
+    public String resolveFieldLink(VariableElement elt) {
+        return javaGen.resolveFieldLink(elt);
     }
 }


### PR DESCRIPTION
1. Fixed inconsistencies in Maven version tags, now compiles out-of-the-box.
2. Fixed duplication in arg names in the generated Clojure methods.
For example, the commit from tychobrailleur/vertx-lang-clojure generates an eventbus/message.clj as follows:
`(defn reply
  ([message message options]
    (.reply message message options))
`
Notice that "message" appeared twice in the arg list, and also in the function. This is likely due to that codegen didn't differentiate the name of the object from the argument.
This PR added "-obj" suffixes in codegen, such that the above becomes:
`(defn reply
  ([message-obj message options]
    (.reply message-obj message options))
`

This PR includes only the code for the bug fix, no test. I'm on the way to set up some tests with Clojure + vert.x eventbus.